### PR TITLE
feat: Add VERSION.md for version badge

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -1,0 +1,1 @@
+## Current Version: 1.1.0


### PR DESCRIPTION
This PR adds a VERSION.md file to display the current project version (1.1.0), which can be used for a version badge.